### PR TITLE
Fix WHMCS 9 compatibility and Mollie payment handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
   "require": {
-    "mollie/mollie-api-php": "^3.7"
+    "mollie/mollie-api-php": "^3.7",
+    "psr/http-message": "^1.1",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0"
   },
   "config": {
     "vendor-dir": "src/mollie/vendor"

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,37 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf5ed5a56673041dedb10fab56defab1",
+    "content-hash": "60312018b18d9f677c99b79fa3c306be",
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.8",
+            "version": "1.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "8a7ecad675253e4654ea05505233285377405215"
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8a7ecad675253e4654ea05505233285377405215",
-                "reference": "8a7ecad675253e4654ea05505233285377405215",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
                 "shasum": ""
             },
             "require": {
                 "ext-openssl": "*",
                 "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8 || ^9",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
@@ -60,235 +61,54 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2020-08-23T12:54:47+00:00"
-        },
-        {
-            "name": "guzzlehttp/guzzle",
-            "version": "7.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7edeaa528fbb57123028bd5a76b9ce9540194e26"
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.12"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7edeaa528fbb57123028bd5a76b9ce9540194e26",
-                "reference": "7edeaa528fbb57123028bd5a76b9ce9540194e26",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.6.1",
-                "php": "^7.2.5",
-                "psr/http-client": "^1.0"
-            },
-            "provide": {
-                "psr/http-client-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "php-http/client-integration-tests": "dev-phpunit8",
-                "phpunit/phpunit": "^8.5.5",
-                "psr/log": "^1.1"
-            },
-            "suggest": {
-                "ext-curl": "Required for CURL handler support",
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
-                "psr/log": "Required for using the Log middleware"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
+                    "url": "https://packagist.com",
+                    "type": "custom"
                 },
                 {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://sagikazarmark.hu"
+                    "url": "https://github.com/composer",
+                    "type": "github"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "psr-18",
-                "psr-7",
-                "rest",
-                "web service"
-            ],
-            "time": "2020-09-22T09:10:04+00:00"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "^4.4 || ^5.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "time": "2020-09-30T07:37:28+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/53330f47520498c0ae1f61f7e2c90f55690c06a3",
-                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
-            },
-            "suggest": {
-                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "time": "2020-09-30T07:37:11+00:00"
+            "time": "2026-05-19T11:26:22+00:00"
         },
         {
             "name": "mollie/mollie-api-php",
-            "version": "v2.23.0",
+            "version": "v3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mollie/mollie-api-php.git",
-                "reference": "bc44a7417a734b92a770213b9f0dc6642e7b5a3c"
+                "reference": "68d3423ee68a3a57819eba37f09889ccbcb6c94c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/bc44a7417a734b92a770213b9f0dc6642e7b5a3c",
-                "reference": "bc44a7417a734b92a770213b9f0dc6642e7b5a3c",
+                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/68d3423ee68a3a57819eba37f09889ccbcb6c94c",
+                "reference": "68d3423ee68a3a57819eba37f09889ccbcb6c94c",
                 "shasum": ""
             },
             "require": {
-                "composer/ca-bundle": "^1.1",
+                "composer/ca-bundle": "^1.4",
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-openssl": "*",
-                "guzzlehttp/guzzle": "^6.3 || ^7.0",
-                "php": ">=5.6"
+                "nyholm/psr7": "^1.8",
+                "php": "^7.4|^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1|^2.0"
             },
             "require-dev": {
-                "eloquent/liberator": "^2.0",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.1"
+                "brianium/paratest": "^6.11",
+                "guzzlehttp/guzzle": "^7.6",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/var-dumper": "^5.4|^6.4|^7.2"
             },
             "suggest": {
                 "mollie/oauth2-mollie-php": "Use OAuth to authenticate with the Mollie API. This is needed for some endpoints. Visit https://docs.mollie.com/ for more information."
@@ -348,25 +168,107 @@
                 "sofortbanking",
                 "subscriptions"
             ],
-            "time": "2020-09-17T13:56:43+00:00"
+            "support": {
+                "issues": "https://github.com/mollie/mollie-api-php/issues",
+                "source": "https://github.com/mollie/mollie-api-php/tree/v3.12.0"
+            },
+            "time": "2026-05-19T07:31:58+00:00"
         },
         {
-            "name": "psr/http-client",
-            "version": "1.0.1",
+            "name": "nyholm/psr7",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0",
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-09T07:06:30+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -386,7 +288,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP clients",
@@ -397,29 +299,87 @@
                 "psr",
                 "psr-18"
             ],
-            "time": "2020-06-29T06:28:15+00:00"
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
-            "name": "psr/http-message",
-            "version": "1.0.1",
+            "name": "psr/http-factory",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -447,55 +407,19 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06T14:39:51+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "time": "2019-03-08T08:55:37+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/src/mollie/callback.php
+++ b/src/mollie/callback.php
@@ -5,93 +5,230 @@
  *
  */
 require_once __DIR__ . '/../../../init.php';
+require_once __DIR__ . '/../../../includes/gatewayfunctions.php';
+require_once __DIR__ . '/../../../includes/invoicefunctions.php';
 require_once __DIR__ . '/vendor/autoload.php';
 
-$whmcs->load_function('gateway');
-$whmcs->load_function('invoice');
+use WHMCS\Database\Capsule;
+
+function mollie_resolve_transaction_from_mollie($paymentId)
+{
+    $configuredGateways = Capsule::table('tblpaymentgateways')
+        ->select(['gateway', 'value'])
+        ->where('setting', 'key')
+        ->where('gateway', 'like', 'mollie%_devapp')
+        ->where('value', '!=', '')
+        ->get();
+
+    foreach ($configuredGateways as $configuredGateway) {
+        try {
+            $mollie = new \Mollie\Api\MollieApiClient();
+            $mollie->setApiKey($configuredGateway->value);
+            $payment = $mollie->payments->get($paymentId);
+
+            $metadata = isset($payment->metadata) ? $payment->metadata : null;
+
+            if (is_array($metadata) && isset($metadata['transaction_id']) && ctype_digit((string) $metadata['transaction_id'])) {
+                $transaction = Capsule::table('gateway_mollie')->where('id', (int) $metadata['transaction_id'])->first();
+            } else if (is_object($metadata) && isset($metadata->transaction_id) && ctype_digit((string) $metadata->transaction_id)) {
+                $transaction = Capsule::table('gateway_mollie')->where('id', (int) $metadata->transaction_id)->first();
+            } else {
+                $transaction = null;
+            }
+
+            if ($transaction) {
+                if (empty($transaction->paymentid)) {
+                    Capsule::table('gateway_mollie')->where('id', $transaction->id)->update(['paymentid' => $paymentId]);
+                    $transaction->paymentid = $paymentId;
+                }
+
+                return array(
+                    'transaction' => $transaction,
+                    'gateway' => $configuredGateway->gateway,
+                    'payment' => $payment,
+                );
+            }
+        } catch (\Throwable $e) {
+            // Continue; this key might not own the payment in Mollie.
+        }
+    }
+
+    return null;
+}
 
 /**
  *
  *    Check parameters
  *
  */
-if (isset($_POST['id'])) {
+if (true) {
+
+    $rawInput = file_get_contents('php://input');
+    $parsedBody = array();
+    if (!empty($rawInput)) {
+        parse_str($rawInput, $parsedBody);
+    }
+
+    $paymentId = '';
+    if (isset($_POST['id']) && is_string($_POST['id'])) {
+        $paymentId = trim($_POST['id']);
+    } else if (isset($_GET['id']) && is_string($_GET['id'])) {
+        $paymentId = trim($_GET['id']);
+    } else if (isset($parsedBody['id']) && is_string($parsedBody['id'])) {
+        $paymentId = trim($parsedBody['id']);
+    }
+
+    $transactionIdHint = null;
+    if (isset($_GET['transaction_id']) && ctype_digit((string) $_GET['transaction_id'])) {
+        $transactionIdHint = (int) $_GET['transaction_id'];
+    }
+
+    if ($paymentId === '') {
+        logTransaction('mollieunknown', array('post' => $_POST, 'get' => $_GET, 'body' => $parsedBody), 'Callback - Failure 0 (Arg mismatch)');
+
+        header('HTTP/1.1 500 Arg mismatch');
+        exit();
+    }
 
     // Get transaction
-    $transactionQuery = select_query('gateway_mollie', '', array('paymentid' => $_POST['id']), null, null, 1);
+    $transaction = null;
 
-    if (mysql_num_rows($transactionQuery) != 1) {
-        logTransaction('mollieunknown', $_POST, 'Callback - Failure 2 (Transaction not found)');
+    if ($transactionIdHint !== null) {
+        $transaction = Capsule::table('gateway_mollie')->where('id', $transactionIdHint)->first();
+
+        if ($transaction && empty($transaction->paymentid)) {
+            Capsule::table('gateway_mollie')->where('id', $transaction->id)->update(['paymentid' => $paymentId]);
+            $transaction->paymentid = $paymentId;
+        }
+    }
+
+    if (!$transaction) {
+        $transaction = Capsule::table('gateway_mollie')->where('paymentid', $paymentId)->first();
+    }
+
+    $resolvedGatewayName = null;
+    $resolvedPayment = null;
+
+    if (!$transaction) {
+        $resolved = mollie_resolve_transaction_from_mollie($paymentId);
+
+        if ($resolved) {
+            $transaction = $resolved['transaction'];
+            $resolvedGatewayName = $resolved['gateway'];
+            $resolvedPayment = $resolved['payment'];
+        }
+    }
+
+    if (!$transaction) {
+        logTransaction('mollieunknown', array('id' => $paymentId, 'transaction_id' => $transactionIdHint, 'post' => $_POST, 'get' => $_GET), 'Callback v9.0.4 - Failure 2 (Transaction not found)');
 
         header('HTTP/1.1 500 Transaction not found');
         exit();
     }
 
-    $transaction = mysql_fetch_assoc($transactionQuery);
-
-    $method = $transaction['method'];
+    $method = $transaction->method;
 
     if (empty($method)) {
         $method = 'checkout';
     }
 
-    $_GATEWAY = getGatewayVariables('mollie' . $method . '_devapp');
+    $_GATEWAY = getGatewayVariables($resolvedGatewayName ? $resolvedGatewayName : ('mollie' . $method . '_devapp'));
 
-    if ($transaction['status'] != 'open') {
-        logTransaction($_GATEWAY['paymentmethod'], array_merge($transaction, $_POST), 'Callback - Failure 3 (Transaction not open)');
+    if (empty($_GATEWAY['type'])) {
+        logTransaction('mollieunknown', array('id' => $paymentId, 'method' => $method), 'Callback - Failure 4 (Gateway not active)');
 
-        header('HTTP/1.1 500 Transaction not open');
+        header('HTTP/1.1 500 Gateway not active');
+        exit();
+    }
+
+    if ($transaction->status != 'open') {
+        logTransaction($_GATEWAY['paymentmethod'], array('transaction' => (array) $transaction, 'callback' => $_POST), 'Callback - Ignored (Transaction not open)');
+
+        header('HTTP/1.1 200 OK');
         exit();
     }
 
     // Get user and transaction currencies
-    $userCurrency = getCurrency($transaction['userid']);
-    $transactionCurrency = select_query('tblcurrencies', '', array('id' => $transaction['currencyid']));
-    $transactionCurrency = mysql_fetch_assoc($transactionCurrency);
+    $userCurrency = getCurrency($transaction->userid);
+    $transactionCurrency = Capsule::table('tblcurrencies')->where('id', $transaction->currencyid)->first();
 
     // Check payment
     $mollie = new \Mollie\Api\MollieApiClient();
     $mollie->setApiKey($_GATEWAY['key']);
 
-    $payment = $mollie->payments->get($_POST['id']);
+    try {
+        $payment = $resolvedPayment ? $resolvedPayment : $mollie->payments->get($paymentId);
+    } catch (\Throwable $e) {
+        logTransaction($_GATEWAY['paymentmethod'], array('id' => $paymentId, 'error' => $e->getMessage()), 'Callback - Failure 5 (Unable to fetch payment)');
+
+        header('HTTP/1.1 500 Unable to fetch payment');
+        exit();
+    }
+
+    if (empty($transaction->paymentid)) {
+        Capsule::table('gateway_mollie')->where('id', $transaction->id)->update(['paymentid' => $paymentId]);
+        $transaction->paymentid = $paymentId;
+    } else if ($transaction->paymentid !== $paymentId) {
+        logTransaction($_GATEWAY['paymentmethod'], array('expected_paymentid' => $transaction->paymentid, 'callback_paymentid' => $paymentId, 'transaction_id' => $transaction->id), 'Callback - Ignored (Payment ID mismatch)');
+
+        header('HTTP/1.1 200 OK');
+        exit();
+    }
+
+    if (isset($payment->metadata)) {
+        $metadata = $payment->metadata;
+        if (is_array($metadata) && isset($metadata['transaction_id']) && ctype_digit((string) $metadata['transaction_id']) && (int) $metadata['transaction_id'] !== (int) $transaction->id) {
+            logTransaction($_GATEWAY['paymentmethod'], array('transaction_id' => $transaction->id, 'metadata_transaction_id' => (int) $metadata['transaction_id'], 'paymentid' => $paymentId), 'Callback - Ignored (Metadata transaction mismatch)');
+
+            header('HTTP/1.1 200 OK');
+            exit();
+        }
+
+        if (is_object($metadata) && isset($metadata->transaction_id) && ctype_digit((string) $metadata->transaction_id) && (int) $metadata->transaction_id !== (int) $transaction->id) {
+            logTransaction($_GATEWAY['paymentmethod'], array('transaction_id' => $transaction->id, 'metadata_transaction_id' => (int) $metadata->transaction_id, 'paymentid' => $paymentId), 'Callback - Ignored (Metadata transaction mismatch)');
+
+            header('HTTP/1.1 200 OK');
+            exit();
+        }
+    }
 
     if ($payment->isPaid()) {
 
         // Add conversion, when there is need to. WHMCS only supports currencies per user. WHY?!
-        if ($transactionCurrency['id'] != $userCurrency['id']) {
-            $transaction['amount'] = convertCurrency($transaction['amount'], $transaction['currencyid'], $userCurrency['id']);
+        $amount = $transaction->amount;
+        if ($transactionCurrency && $transactionCurrency->id != $userCurrency['id']) {
+            $amount = convertCurrency($amount, $transaction->currencyid, $userCurrency['id']);
         }
 
         // Check invoice
-        $invoiceid = checkCbInvoiceID($transaction['invoiceid'], $_GATEWAY['paymentmethod']);
+        $invoiceid = checkCbInvoiceID($transaction->invoiceid, $_GATEWAY['paymentmethod']);
 
-        checkCbTransID($transaction['paymentid']);
+        checkCbTransID($paymentId);
 
         // Add invoice
-        addInvoicePayment($invoiceid, $transaction['paymentid'], $transaction['amount'], '', $_GATEWAY['paymentmethod']);
+        addInvoicePayment($invoiceid, $paymentId, $amount, '', $_GATEWAY['paymentmethod']);
 
-        update_query('gateway_mollie', array('status' => 'paid', 'updated' => date('Y-m-d H:i:s', time())), array('id' => $transaction['id']));
+        Capsule::table('gateway_mollie')->where('id', $transaction->id)->update(['status' => 'paid', 'updated' => date('Y-m-d H:i:s')]);
+        $transaction->status = 'paid';
+        $transaction->updated = date('Y-m-d H:i:s');
 
-        logTransaction($_GATEWAY['paymentmethod'], array_merge($transaction, $_POST), 'Callback - Successful (Paid)');
+        logTransaction($_GATEWAY['paymentmethod'], array('transaction' => (array) $transaction, 'callback' => $_POST), 'Callback - Successful (Paid)');
 
         header('HTTP/1.1 200 OK');
         exit();
     } else if ($payment->isOpen() == FALSE) {
-        update_query('gateway_mollie', array('status' => 'closed', 'updated' => date('Y-m-d H:i:s', time())), array('id' => $transaction['id']));
+        Capsule::table('gateway_mollie')->where('id', $transaction->id)->update(['status' => 'closed', 'updated' => date('Y-m-d H:i:s')]);
+        $transaction->status = 'closed';
+        $transaction->updated = date('Y-m-d H:i:s');
 
-        logTransaction($_GATEWAY['paymentmethod'], array_merge($transaction, $_POST), 'Callback - Successful (Closed)');
+        logTransaction($_GATEWAY['paymentmethod'], array('transaction' => (array) $transaction, 'callback' => $_POST), 'Callback - Successful (Closed)');
 
         header('HTTP/1.1 200 OK');
         exit();
     } else {
-        logTransaction($_GATEWAY['paymentmethod'], array_merge($transaction, $_POST), 'Callback - Failure 1 (Payment not open or paid)');
+        logTransaction($_GATEWAY['paymentmethod'], array('transaction' => (array) $transaction, 'callback' => $_POST), 'Callback - Pending (Payment still open)');
 
-        header('HTTP/1.1 500 Payment not open or paid');
+        header('HTTP/1.1 200 OK');
         exit();
     }
-} else {
-    logTransaction('mollieunknown', $_POST, 'Callback - Failure 0 (Arg mismatch)');
-
-    header('HTTP/1.1 500 Arg mismatch');
-    exit();
 }

--- a/src/mollie/mollie.php
+++ b/src/mollie/mollie.php
@@ -1,5 +1,7 @@
 <?php
 
+use WHMCS\Database\Capsule;
+
 require_once __DIR__ . '/vendor/autoload.php';
 
 function mollie_config()
@@ -14,7 +16,7 @@ function mollie_config()
     );
 }
 
-function mollie_link($params, $method = Mollie_API_Object_Method::IDEAL)
+function mollie_link($params, $method = \Mollie\Api\Types\PaymentMethod::IDEAL)
 {
     global $whmcs;
 
@@ -38,16 +40,20 @@ function mollie_link($params, $method = Mollie_API_Object_Method::IDEAL)
     /* @var array $_GATEWAYLANG */
     require __DIR__ . '/lang/' . $params['language'] . '.php';
 
-    $tableCheckQuery = full_query('SHOW TABLES LIKE \'gateway_mollie\'');
-
-    if (mysql_num_rows($tableCheckQuery) != 1) {
-        full_query('CREATE TABLE IF NOT EXISTS `gateway_mollie` (`id` int(11) NOT NULL AUTO_INCREMENT, `paymentid` varchar(64), `amount` double NOT NULL, `currencyid` int(11) NOT NULL, `ip` varchar(50) NOT NULL, `userid` int(11) NOT NULL, `invoiceid` int(11) NOT NULL, `status` ENUM(\'open\',\'paid\',\'closed\') NOT NULL DEFAULT \'open\', `method` VARCHAR(25) NOT NULL,  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated` timestamp NULL DEFAULT NULL, PRIMARY KEY (`id`), UNIQUE KEY `paymentid` (`paymentid`)) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;');
-    }
-
-    $paymentIdQuery = full_query("SHOW COLUMNS FROM `gateway_mollie` WHERE `Field` = 'paymentid' AND `Type` LIKE '%64%'");
-
-    if (mysql_num_rows($paymentIdQuery) == 0) {
-        full_query("ALTER TABLE `gateway_mollie` CHANGE `paymentid` `paymentid` VARCHAR(64);");
+    if (!Capsule::schema()->hasTable('gateway_mollie')) {
+        Capsule::schema()->create('gateway_mollie', function ($table) {
+            $table->increments('id');
+            $table->string('paymentid', 64)->nullable()->unique();
+            $table->double('amount');
+            $table->integer('currencyid');
+            $table->string('ip', 50);
+            $table->integer('userid');
+            $table->integer('invoiceid');
+            $table->enum('status', ['open', 'paid', 'closed'])->default('open');
+            $table->string('method', 25);
+            $table->timestamp('created')->useCurrent();
+            $table->timestamp('updated')->nullable();
+        });
     }
 
     $mollie = new \Mollie\Api\MollieApiClient();
@@ -59,61 +65,151 @@ function mollie_link($params, $method = Mollie_API_Object_Method::IDEAL)
      *
      */
     if (isset($_GET['check_payment']) && ctype_digit($_GET['check_payment'])) {
-        $transactionQuery = select_query('gateway_mollie', '', array('id' => $_GET['check_payment']), null, null, 1);
+        $transaction = Capsule::table('gateway_mollie')->where('id', (int) $_GET['check_payment'])->first();
 
-        if (mysql_num_rows($transactionQuery) != 1) {
+        if (!$transaction) {
             return '<p>' . $_GATEWAYLANG['errorTransactionNotFound'] . '</p>';
         }
 
-        $transaction = mysql_fetch_assoc($transactionQuery);
-
-        if ($transaction['status'] == 'paid') {
+        if ($transaction->status == 'paid') {
             header('location: ' . $params['returnurl'] . '&paymentsuccess=true');
             exit();
-        } else if ($transaction['status'] == 'closed') {
+        } else if ($transaction->status == 'closed') {
             header('location: ' . $params['returnurl'] . '&paymentfailed=true');
             exit();
         } else {
+            if (!empty($transaction->paymentid)) {
+                // DB hasn't been updated by webhook yet — poll Mollie directly.
+                try {
+                    $pollPayment = $mollie->payments->get($transaction->paymentid);
+
+                    if ($pollPayment->isPaid()) {
+                        Capsule::table('gateway_mollie')
+                            ->where('id', $transaction->id)
+                            ->update(['status' => 'paid', 'updated' => date('Y-m-d H:i:s')]);
+                        header('location: ' . $params['returnurl'] . '&paymentsuccess=true');
+                        exit();
+                    } else if (!$pollPayment->isOpen()) {
+                        Capsule::table('gateway_mollie')
+                            ->where('id', $transaction->id)
+                            ->update(['status' => 'closed', 'updated' => date('Y-m-d H:i:s')]);
+                        header('location: ' . $params['returnurl'] . '&paymentfailed=true');
+                        exit();
+                    }
+                } catch (\Throwable $e) {
+                    // Mollie unreachable — keep spinning.
+                }
+            }
+
             return '<br/><img src="' . $params['systemurl'] . 'modules/gateways/mollie/ajax_loader.gif" /><br/>' . $_GATEWAYLANG['checkPayment'] . ' <script> window.onload = function(){ setTimeout("location.reload(true);", 2000); } </script>';
         }
     } else {
-        if (isset($_POST['start']) || isset($_POST['issuer']) || (isset($_GET['a']) && $_GET['a'] == 'complete') || (isset($_GET['action']) && ($_GET['action'] == 'addfunds' || $_GET['action'] == 'masspay') && isset($_POST['paymentmethod']) && $_POST['paymentmethod'] == 'mollie' . $method)) {
+        $isAddFundsOrMassPayStart = isset($_GET['action'])
+            && ($_GET['action'] == 'addfunds' || $_GET['action'] == 'masspay')
+            && isset($_POST['paymentmethod'])
+            && $_POST['paymentmethod'] == 'mollie' . $method;
 
-            $transactionCurrency = select_query('tblcurrencies', '', array('code' => $params['currency']), null, null, 1);
-            $transactionCurrency = mysql_fetch_assoc($transactionCurrency);
+        if (isset($_POST['start']) || isset($_POST['issuer']) || $isAddFundsOrMassPayStart) {
 
-            $transactionId = insert_query('gateway_mollie', array(
-                'amount' => $params['amount'],
-                'currencyid' => $transactionCurrency['id'],
-                'ip' => $_SERVER['REMOTE_ADDR'],
-                'userid' => $params['clientdetails']['userid'],
-                'invoiceid' => $params['invoiceid'],
-                'method' => $method
-            ));
+            $existingTransaction = Capsule::table('gateway_mollie')
+                ->where('invoiceid', (int) $params['invoiceid'])
+                ->where('userid', (int) $params['clientdetails']['userid'])
+                ->where('method', $method)
+                ->where('status', 'open')
+                ->orderBy('id', 'desc')
+                ->first();
 
-            $payment = $mollie->payments->create(array(
+            if ($existingTransaction && !empty($existingTransaction->paymentid)) {
+                try {
+                    $existingPayment = $mollie->payments->get($existingTransaction->paymentid);
+
+                    if ($existingPayment->isOpen()) {
+                        header('Location: ' . $existingPayment->getCheckoutUrl());
+                        exit();
+                    }
+
+                    if (!$existingPayment->isPaid()) {
+                        Capsule::table('gateway_mollie')
+                            ->where('id', $existingTransaction->id)
+                            ->update(['status' => 'closed', 'updated' => date('Y-m-d H:i:s')]);
+                    }
+                } catch (\Throwable $e) {
+                    // If we can't resolve prior payment state, continue and create a new payment.
+                }
+            }
+
+            $transactionCurrency = Capsule::table('tblcurrencies')->where('code', $params['currency'])->first();
+            $resolvedCurrencyId = $transactionCurrency ? (int) $transactionCurrency->id : 0;
+
+            if ($resolvedCurrencyId === 0) {
+                $userCurrency = getCurrency((int) $params['clientdetails']['userid']);
+                if (is_array($userCurrency) && isset($userCurrency['id']) && ctype_digit((string) $userCurrency['id'])) {
+                    $resolvedCurrencyId = (int) $userCurrency['id'];
+                }
+            }
+
+            if ($resolvedCurrencyId === 0) {
+                logTransaction(
+                    isset($params['paymentmethod']) ? $params['paymentmethod'] : ('mollie' . $method . '_devapp'),
+                    array('invoiceid' => $params['invoiceid'], 'currency' => $params['currency']),
+                    'Link - Failure (Unable to resolve currencyid)'
+                );
+
+                return '<p>Unable to determine invoice currency for this payment.</p>';
+            }
+
+            $transactionId = Capsule::table('gateway_mollie')->insertGetId([
+                'amount'     => $params['amount'],
+                'currencyid' => $resolvedCurrencyId,
+                'ip'         => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '',
+                'userid'     => $params['clientdetails']['userid'],
+                'invoiceid'  => $params['invoiceid'],
+                'method'     => $method,
+            ]);
+
+            $paymentData = array(
                 'amount' => [
-                    'value' => $params['amount'],
+                    'value' => number_format((float) $params['amount'], 2, '.', ''),
                     'currency' => $params['currency'],
                 ],
-                'method' => $method,
                 'description' => $params['description'],
                 'redirectUrl' => $params['returnurl'] . '&check_payment=' . $transactionId,
-                'webhookUrl' => $params['systemurl'] . '/modules/gateways/mollie/callback.php',
+                'webhookUrl' => $params['systemurl'] . '/modules/gateways/mollie/callback.php?transaction_id=' . $transactionId,
                 'metadata' => array(
                     'invoice_id' => $params['invoiceid'],
+                    'transaction_id' => $transactionId,
                 ),
-                'dueDate' => (($method == \Mollie\Api\Types\PaymentMethod::BANKTRANSFER) ? date('Y-m-d', strtotime('+100 days')) : NULL),
-            ));
+            );
 
-            update_query('gateway_mollie', array('paymentid' => $payment->id), array('id' => $transactionId));
+            if (!empty($method)) {
+                $paymentData['method'] = $method;
+            }
+
+            if ($method == \Mollie\Api\Types\PaymentMethod::BANKTRANSFER) {
+                $paymentData['dueDate'] = date('Y-m-d', strtotime('+100 days'));
+            }
+
+            try {
+                $payment = $mollie->payments->create($paymentData);
+            } catch (\Mollie\Api\Exceptions\ApiException $e) {
+                Capsule::table('gateway_mollie')->where('id', $transactionId)->whereNull('paymentid')->delete();
+                return '<p>' . htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8') . '</p>';
+            }
+
+            Capsule::table('gateway_mollie')->where('id', $transactionId)->update(['paymentid' => $payment->id]);
 
             header('Location: ' . $payment->getCheckoutUrl());
             exit();
         } else {
             $return = '<form action="viewinvoice.php?id=' . $params['invoiceid'] . '" method="POST">';
 
-            $return .= '<input type="submit" name="start" value="' . $_GATEWAYLANG['payWith' . ucfirst($method)] . '" /></form>';
+            $methodLabelKey = !empty($method) ? ('payWith' . ucfirst($method)) : 'payWith';
+
+            if (!isset($_GATEWAYLANG[$methodLabelKey])) {
+                $methodLabelKey = 'payWith';
+            }
+
+            $return .= '<input type="submit" name="start" value="' . $_GATEWAYLANG[$methodLabelKey] . '" /></form>';
 
             return $return;
         }


### PR DESCRIPTION
This PR fixes multiple issues affecting the Mollie gateway on WHMCS 9.x, tested against WHMCS 9.0.4.

Main changes:
- replace legacy WHMCS DB helper usage with WHMCS\Database\Capsule
- fix transaction persistence and currency resolution under WHMCS 9
- improve webhook matching using transaction metadata and transaction_id hints
- prevent duplicate payment creation for the same open invoice/payment method
- harden callback validation to avoid false paid attribution
- stop unnecessary Mollie webhook retry loops by returning HTTP 200 for ignored and non-actionable cases
- let the check_payment flow poll Mollie directly when the local transaction is still open

This branch intentionally excludes fork-specific README and changelog changes so the PR stays focused on upstream-safe fixes.

These changes were prepared and validated in the ICT Shift fork while testing compatibility with WHMCS 9.0.4, and are submitted here to help keep the main project compatible with newer WHMCS versions.